### PR TITLE
fix peek timespan

### DIFF
--- a/src/termbox2.cr
+++ b/src/termbox2.cr
@@ -100,7 +100,7 @@ module Termbox
   # Waits for an event up to *timeout* and returns a `BaseEvent`,
   # or nil if no event is available within the timeout.
   def peek?(timeout : Time::Span) : BaseEvent?
-    peek?(timeout.milliseconds)
+    peek?(timeout.total_milliseconds)
   end
 
   # Waits for an event up to *timeout* milliseconds and


### PR DESCRIPTION
Fixes the peek?(timeout : Time::Span) method by replacing `milliseconds` with `total_milliseconds`, since `milliseconds` only returns the sub-second component and wraps around every 1000ms. Using `total_milliseconds` ensures correct timeout durations.
The current behaviour causes problems when doing something like `event = Termbox.peek? 10.seconds` as it will be equivalent to `event = Termbox.peek? 0` rather than `event = Termbox.peek? 10000`